### PR TITLE
Skip Non-Skeleton File during data import

### DIFF
--- a/data_gen/ntu120_gendata.py
+++ b/data_gen/ntu120_gendata.py
@@ -105,7 +105,7 @@ def gendata(data_path, out_path, ignored_sample_path=None, benchmark='xsetup', p
     # print(data_path)
     for filename in os.listdir(data_path):
         # print(ignored_samples)
-        if filename in ignored_samples:
+        if filename in ignored_samples or filename == os.path.basename(ignored_sample_path):
             continue
         # print('==============')
         # print(filename)

--- a/data_gen/ntu_gendata.py
+++ b/data_gen/ntu_gendata.py
@@ -104,7 +104,7 @@ def gendata(data_path, out_path, ignored_sample_path=None, benchmark='xview', pa
     # print(data_path)
     for filename in os.listdir(data_path):
         # print(ignored_samples)
-        if filename in ignored_samples:
+        if filename in ignored_samples or filename == os.path.basename(ignored_sample_path)::
             continue
         # print('==============')
         # print(filename)

--- a/data_gen/ntu_gendata.py
+++ b/data_gen/ntu_gendata.py
@@ -104,7 +104,7 @@ def gendata(data_path, out_path, ignored_sample_path=None, benchmark='xview', pa
     # print(data_path)
     for filename in os.listdir(data_path):
         # print(ignored_samples)
-        if filename in ignored_samples or filename == os.path.basename(ignored_sample_path)::
+        if filename in ignored_samples or filename == os.path.basename(ignored_sample_path):
             continue
         # print('==============')
         # print(filename)


### PR DESCRIPTION
When parsing all content of the `data/nturgbd_raw`  `data/nturgbd120_raw`  directories, the following files are found as well:
- `NTU_RGBD_samples_with_missing_skeletons.txt` 
- `NTU_RGBD120_samples_with_missing_skeletons.txt`

In code, the line `action_class = int(filename[filename.find('A') + 1:filename.find('A') + 4])` will fail for these files.
This is because those are not named in the NTU dataset scheme and contain no letter `A`. 
The expression will be resolved to `int(filename[0:3])` which equals `int('NTU')`. 
`NTU` cannot be converted to an int, which is why the code execution gets stopped.

The fix is to skip these two files during parsing of NTU dataset files.
