### PR TITLE
Update decouple_gcn.py

### DIFF
--- a/model/decouple_gcn.py
+++ b/model/decouple_gcn.py
@@ -229,6 +229,7 @@ class Model(nn.Module):
 
         # N*M,C,T,V
         c_new = x.size(1)
+        x = x.contiguous()
         x = x.view(N, M, c_new, -1)
         x = x.mean(3).mean(1)
 


### PR DESCRIPTION
Added x.contiguous() on line 232 to avoid this error: 

> RuntimeError: view size is not compatible with the input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.

For more information, check [issue](https://github.com/cezannec/capsule_net_pytorch/issues/4l)